### PR TITLE
WIP: Drag to select

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -221,6 +221,20 @@ const Calendar = ({
     return allDays;
   };
 
+  function onDaySelect(date) {
+    dispatchSelectedDays({ type: 'SELECT', date });
+  }
+
+  function onDayEnter(date, isStandard = true) {
+    if (isStandard && currentlyDragging) {
+      dispatchSelectedDays({ type: 'ENTER', date });
+    }
+  }
+
+  function onDayRelease(date) {
+    dispatchSelectedDays({ type: 'RELEASE', date });
+  }
+
   const renderMonthDays = isNewMonth => {
     const allDays = getViewMonthDays(isNewMonth);
     return allDays.map(({ id, value: day, month, year, isStandard }) => {
@@ -232,15 +246,19 @@ const Calendar = ({
           key={id}
           className={`Calendar__day ${additionalClass}`}
           onMouseDown={() => {
-            dispatchSelectedDays({ type: 'SELECT', date: { day, month, year } });
+            onDaySelect(dayItem, isStandard);
           }}
           onMouseEnter={() => {
-            if (isStandard && currentlyDragging) {
-              dispatchSelectedDays({ type: 'ENTER', date: { day, month, year } });
-            }
+            onDayEnter(dayItem, isStandard);
           }}
           onMouseUp={() => {
-            dispatchSelectedDays({ type: 'RELEASE', date: { day, month, year } });
+            onDayRelease(dayItem, isStandard);
+          }}
+          onTouchStart={() => {
+            onDaySelect(dayItem, isStandard);
+          }}
+          onTouchEnd={() => {
+            onDayRelease(dayItem, isStandard);
           }}
           disabled={!isStandard}
           type="button"

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -225,7 +225,7 @@ const Calendar = ({
     dispatchSelectedDays({ type: 'SELECT', date });
   }
 
-  function onDayEnter(date, isStandard = true) {
+  function onDayEnter(date, isStandard) {
     if (isStandard && currentlyDragging) {
       dispatchSelectedDays({ type: 'ENTER', date });
     }

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -244,6 +244,9 @@ const Calendar = ({
       return (
         <button
           key={id}
+          data-year={year}
+          data-month={month}
+          data-day={day}
           className={`Calendar__day ${additionalClass}`}
           onMouseDown={() => {
             onDaySelect(dayItem, isStandard);
@@ -256,6 +259,35 @@ const Calendar = ({
           }}
           onTouchStart={() => {
             onDaySelect(dayItem, isStandard);
+          }}
+          onTouchMove={e => {
+            const touchStartedFrom = e.currentTarget;
+            const currentlyTouched = document.elementFromPoint(
+              e.targetTouches[0].pageX,
+              e.targetTouches[0].pageY,
+            );
+            const getDateFromDOMNode = domNODE => {
+              const { year: yearString, month: monthString, day: dayString } = domNODE.dataset;
+              return {
+                year: Number(yearString),
+                month: Number(monthString),
+                day: Number(dayString),
+                isStandard:
+                  yearString !== undefined && monthString !== undefined && dayString !== undefined,
+              };
+            };
+            if (touchStartedFrom !== currentlyTouched) {
+              const {
+                year: currentlyTouchedYear,
+                month: currentlyTouchedMonth,
+                day: currentlyTouchedDay,
+                isStandard: currentlyTouchedIsStandard,
+              } = getDateFromDOMNode(currentlyTouched);
+              onDayEnter(
+                { currentlyTouchedYear, currentlyTouchedMonth, currentlyTouchedDay },
+                currentlyTouchedIsStandard,
+              );
+            }
           }}
           onTouchEnd={() => {
             onDayRelease(dayItem, isStandard);

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -70,11 +70,17 @@ const Calendar = ({
             secondSelectedDay: date,
             currentlyDragging: 'FIRST',
           };
-        } else if (isSameDay(date, firstSelectedDay)) {
+        } else if (isSameDay(date, firstSelectedDay) && secondSelectedDay) {
           newState = {
             firstSelectedDay: date,
             secondSelectedDay,
             currentlyDragging: 'FIRST',
+          };
+        } else if (isSameDay(date, firstSelectedDay) && !secondSelectedDay) {
+          newState = {
+            firstSelectedDay,
+            secondSelectedDay,
+            currentlyDragging: 'SECOND',
           };
         } else if (isSameDay(date, secondSelectedDay)) {
           newState = {
@@ -88,7 +94,7 @@ const Calendar = ({
             secondSelectedDay,
             currentlyDragging: 'SECOND',
           };
-        } else if (secondSelectedDay) {
+        } else if (firstSelectedDay && secondSelectedDay) {
           newState = {
             firstSelectedDay: date,
             secondSelectedDay: null,

--- a/src/DatePicker.css
+++ b/src/DatePicker.css
@@ -217,6 +217,7 @@
   border-radius: 50%;
   transition: 0.2s;
   border: 1px solid transparent;
+  touch-action: none;
 }
 
 .Calendar__day:not(.-blank):not(.-selectedStart):not(.-selectedEnd):not(.-selectedBetween):not(.-selected):hover {

--- a/src/DatePicker.js
+++ b/src/DatePicker.js
@@ -53,7 +53,7 @@ const DatePicker = ({
     if (shouldCloseCalendar) dateInput.current.blur();
   }, [selectedDay, isCalendarOpen]);
 
-  const toggleCalendar = () => setCalendarVisiblity(!isCalendarOpen);
+  const toggleCalendar = () => setCalendarVisiblity(true);
 
   // keep calendar open if clicked inside the calendar
   const handleBlur = e => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -105,6 +105,9 @@ const checkDayInDayRange = ({ day, from, to }) => {
   return nativeDay > nativeFrom && nativeDay < nativeTo;
 };
 
+const checkDayInDayRangeIncluding = ({ day, from, to }) =>
+  checkDayInDayRange({ day, from, to }) || isSameDay(day, from) || isSameDay(day, to);
+
 const putZero = number => (number.toString().length === 1 ? `0${number}` : number);
 
 const shallowCloneObject = obj => ({ ...obj });
@@ -123,6 +126,7 @@ export {
   getDateAccordingToMonth,
   isSameDay,
   checkDayInDayRange,
+  checkDayInDayRangeIncluding,
   isBeforeDate,
   putZero,
   shallowCloneObject,


### PR DESCRIPTION
Add drag to select support for dayRangeCalendar

**Todo**:
- [x] Implement drag to select functionality
- [x] Fix onDisabledDayError functionality
- [x] Fix bug when after selecting the range completely at one side of a disabled day, we can't reset our selection either select the first day at the opposite side
- [x] Improve behavior when the user selects one day by a simple click and then starts dragging from the selected day (intended behavior is selecting the second state instead of changing the first one)
- [x] Fix bug reported by [this](https://github.com/Kiarash-Z/react-persian-calendar-date-picker/pull/2#issuecomment-488601331) comment (second gif)
- [ ] Add support for touchscreens
- [ ] Fix functionality for single day date picker use case
- [ ] Find a better workaround for closing Calendar after selection is completed (I'm thinking of something like using a callback named onSelectCompleted or so)
- [ ] Document these changes

related to issues: #1